### PR TITLE
Handle undefined app.options.fingerprint

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -8,6 +8,7 @@ var Utilities = (function() {
   return {
     treePath: path.join('node_modules', 'ember-cli-chrome', 'chrome-files'),
     disableFingerPrints: function(app) {
+      app.options.fingerprint = app.options.fingerprint || {};
       app.options.fingerprint.enabled = false;
     },
     addChromeHelper: function(app) {


### PR DESCRIPTION
This fixes the error:
TypeError: Cannot set property 'enabled' of undefined
(https://github.com/j-mcnally/ember-cli-chrome/issues/9)

I used the same solution from here:
https://github.com/rondale-sc/ember-cli-rails-addon/issues/6